### PR TITLE
add a blog post from indico

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ More info [here](http://tensorflow.org).
 * [TensorFlow for Poets](http://petewarden.com/2016/02/28/tensorflow-for-poets) - Goes over the implementation of TensorFlow
 * [Introduction to Scikit Flow - Simplified Interface to TensorFlow](http://terrytangyuan.github.io/2016/03/14/scikit-flow-intro/) - Key Features Illustrated
 * [The indico Machine Learning Team's take on TensorFlow](https://indico.io/blog/indico-tensorflow) 
+* [The Good, Bad, & Ugly of TensorFlow](https://indico.io/blog/the-good-bad-ugly-of-tensorflow/) - A survey of six months rapid evolution (+ tips/hacks and code to fix the ugly stuff), Dan Kuster at Indico, May 9, 2016
 
 
 <a name="community" />


### PR DESCRIPTION
From reddit:
"This is a nice writeup, and the trick of using the env var CUDA_VISIBLE_DEVICES is very critical to know about (also for Torch, which insists on allocating space on all GPUs just in case you want to do multigpu, which clutters nvidia-smi with "fake" jobs), as well as the gotcha that the numbers there don't correspond to nvidia-smi numbers (I had to figure that out the hard way)."