### PR TITLE
Update README.MD to include NNFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ More info [here](http://tensorflow.org).
 * [keras](http://keras.io) - Minimal, modular deep learning library for TensorFlow and Theano
 * [SyntaxNet: Neural Models of Syntax](https://github.com/tensorflow/models/tree/master/syntaxnet) - A TensorFlow implementation of the models described in [Globally Normalized Transition-Based Neural Networks, Andor et al. (2016)](http://arxiv.org/pdf/1603.06042.pdf)
 * [keras-js](https://github.com/transcranial/keras-js) - Run Keras models (tensorflow backend) in the browser, with GPU support
+* [NNFlow](https://github.com/welschma/NNFlow)  Simple framework allowing to read-in ROOT NTuples by converting them to a Numpy array and then use them in Google Tensorflow.
 
 <a name="video" />
 ##Videos


### PR DESCRIPTION
NNFlow is a simple framework to convert CERN's ROOT data files in a way that they can be used by Tensorflow. This framework is useful for the high-energy physics analysis groups.