### PR TITLE
Add create-tf-app to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ More info [here](http://tensorflow.org).
 * [Nebullvm](https://github.com/nebuly-ai/nebullvm) - Easy-to-use library to boost AI inference leveraging multiple deep learning compilers.
 * [Guild AI](https://guild.ai) - Task runner and package manager for TensorFlow
 * [ML Workspace](https://github.com/ml-tooling/ml-workspace) - All-in-one web IDE for machine learning and data science. Combines Tensorflow, Jupyter, VS Code, Tensorboard, and many other tools/libraries into one Docker image.
+* [create-tf-app](https://github.com/radi-cho/create-tf-app) - Project builder command line tool for Tensorflow covering environment management, linting, and logging.
 
 <a name="video" />
 


### PR DESCRIPTION
Hello,
I think https://github.com/radi-cho/create-tf-app is a good fit for the tools section of this list.
`create-tf-app` is a project builder command line tool for Tensorflow, which covers environment management with conda, linting, logging, and visualizations with Tensorboard.